### PR TITLE
fixed telemetry issue (relay not connecting to kubearmor)

### DIFF
--- a/relay-server/server/relayServer.go
+++ b/relay-server/server/relayServer.go
@@ -322,7 +322,7 @@ func NewClient(server string) *LogClient {
 	// == //
 
 	msgIn := pb.RequestMessage{}
-	msgIn.Filter = ""
+	msgIn.Filter = "all"
 
 	msgStream, err := lc.client.WatchMessages(context.Background(), &msgIn)
 	if err != nil {


### PR DESCRIPTION
Filter is now a mandatory parameter when calling Watch* APIs, hence `WatchMessages()` was failing because filter will `""`.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>