### PR TITLE
Upgrade Dockerfile image to 1.20-alpine3.17

### DIFF
--- a/relay-server/Dockerfile
+++ b/relay-server/Dockerfile
@@ -1,6 +1,6 @@
 ### Builder
 
-FROM golang:1.15.2-alpine3.12 as builder
+FROM golang:1.20-alpine3.17 as builder
 
 RUN apk update
 RUN apk add --no-cache make


### PR DESCRIPTION
We were using outdated go version for building the image in Dockerfile.

https://stackoverflow.com/a/68752298