### PR TITLE
updating nodelist to get podIP instead of hostIP

### DIFF
--- a/relay-server/server/k8sHandler.go
+++ b/relay-server/server/k8sHandler.go
@@ -266,12 +266,12 @@ func (kh *K8sHandler) GetKubeArmorNodes() []string {
 		} else if val != "kubearmor" {
 			continue
 		}
-		if pod.Status.HostIP == "" {
+		if pod.Status.PodIP == "" {
 			kg.Printf("pod.Status=%+v", pod.Status)
 		}
 
-		if pod.Status.HostIP != "" && !containsElement(nodeIPs, pod.Status.HostIP) {
-			nodeIPs = append(nodeIPs, pod.Status.HostIP)
+		if pod.Status.PodIP != "" && !containsElement(nodeIPs, pod.Status.PodIP) {
+			nodeIPs = append(nodeIPs, pod.Status.PodIP)
 		}
 	}
 


### PR DESCRIPTION
in preparation for [#1392](https://github.com/kubearmor/KubeArmor/pull/1392)

Kubearmor soon will **not** be using `hostNetwork=true`  
which would mean that the IP of kubearmor daemonset will not be same as the node 

hence getting podIP instead on hostIP