### PR TITLE
fix(server): use pod-name:pod-ip as node identity for kubearmor daemon

### DIFF
--- a/relay-server/go.mod
+++ b/relay-server/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
-	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20240412061210-e4422dd02342
 	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20240315075053-fee50c9428b9
@@ -35,6 +34,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/relay-server/server/relayServer.go
+++ b/relay-server/server/relayServer.go
@@ -712,14 +712,18 @@ func DeleteClientEntry(nodeIP string) {
 // == KubeArmor == //
 // =============== //
 
-func connectToKubeArmor(nodeIP, port string) error {
+func connectToKubeArmor(nodeID, port string) error {
 
+	nodeIP, err := extractIP(nodeID)
+	if err != nil {
+		return err
+	}
 	// create connection info
 	server := nodeIP + ":" + port
 
 	for Running {
 		ClientListLock.RLock()
-		_, found := ClientList[nodeIP]
+		_, found := ClientList[nodeID]
 		ClientListLock.RUnlock()
 		if !found {
 			// KubeArmor with this IP is deleted or the IP has changed


### PR DESCRIPTION
to avoid the case, if kubearmor pod recreated for any reason and pod deletion event received after pod added event then node will be removed from current list of nodes/kubearmor-pods if node id is created using node-ip only.

```bash
{"level":"warn","ts":"2024-11-21 13:42:55.674541","caller":"log/logger.go:79","msg":"failed to receive an alert (192.168.29.159:32767) rpc error: code = Unavailable desc = error reading from server: EOF"}
{"level":"info","ts":"2024-11-21 13:42:55.674623","caller":"log/logger.go:54","msg":"Destroyed the client (192.168.29.159:32767)"}
{"level":"warn","ts":"2024-11-21 13:42:55.674978","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"info","ts":"2024-11-21 13:42:55.874444","caller":"log/logger.go:54","msg":"[addevent] pod kubearmor-bpf-containerd-98c2c-4krn9 has been added"}
{"level":"info","ts":"2024-11-21 13:42:56.273261","caller":"log/logger.go:54","msg":"[deleteEvent] pod kubearmor-bpf-containerd-98c2c-s9bnk has been deleted"}
{"level":"info","ts":"2024-11-21 13:42:56.273329","caller":"log/logger.go:54","msg":"pod with nodeip 192.168.29.159 deleted"}
```