### PR TITLE
fix(adapter): fix elk client panic issue due to uninitialized waitgroup, ctx

### DIFF
--- a/relay-server/elasticsearch/adapter.go
+++ b/relay-server/elasticsearch/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	kg "github.com/kubearmor/kubearmor-relay-server/relay-server/log"
 	"github.com/kubearmor/kubearmor-relay-server/relay-server/server"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -116,7 +117,8 @@ func (ecl *ElasticsearchClient) Start() error {
 	start = time.Now()
 	client := ecl.kaClient
 	ecl.ctx, ecl.cancel = context.WithCancel(context.Background())
-
+	client.WgServer = &errgroup.Group{}
+	client.Context = ecl.ctx
 	// do healthcheck
 	if ok := client.DoHealthCheck(); !ok {
 		return fmt.Errorf("failed to check the liveness of the gRPC server")

--- a/relay-server/elasticsearch/adapter.go
+++ b/relay-server/elasticsearch/adapter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,9 +16,8 @@ import (
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esutil"
 	"github.com/google/uuid"
+	pb "github.com/kubearmor/KubeArmor/protobuf"
 	kg "github.com/kubearmor/kubearmor-relay-server/relay-server/log"
-	"github.com/kubearmor/kubearmor-relay-server/relay-server/server"
-	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -28,7 +28,6 @@ var (
 
 // ElasticsearchClient Structure
 type ElasticsearchClient struct {
-	kaClient    *server.LogClient
 	esClient    *elasticsearch.Client
 	cancel      context.CancelFunc
 	bulkIndexer esutil.BulkIndexer
@@ -39,7 +38,7 @@ type ElasticsearchClient struct {
 // NewElasticsearchClient creates a new Elasticsearch client with the given Elasticsearch URL
 // and kubearmor LogClient with endpoint. It has a retry mechanism for certain HTTP status codes and a backoff function for retry delays.
 // It then creates a new NewBulkIndexer with the esClient
-func NewElasticsearchClient(esURL, Endpoint string) (*ElasticsearchClient, error) {
+func NewElasticsearchClient(esURL string) (*ElasticsearchClient, error) {
 	retryBackoff := backoff.NewExponentialBackOff()
 	cfg := elasticsearch.Config{
 		Addresses: []string{esURL},
@@ -70,8 +69,7 @@ func NewElasticsearchClient(esURL, Endpoint string) (*ElasticsearchClient, error
 		log.Fatalf("Error creating the indexer: %s", err)
 	}
 	alertCh := make(chan interface{}, 10000)
-	kaClient := server.NewClient(Endpoint)
-	return &ElasticsearchClient{kaClient: kaClient, bulkIndexer: bi, esClient: esClient, alertCh: alertCh}, nil
+	return &ElasticsearchClient{bulkIndexer: bi, esClient: esClient, alertCh: alertCh}, nil
 }
 
 // bulkIndex takes an interface and index name and adds the data to the Elasticsearch bulk indexer.
@@ -109,71 +107,39 @@ func (ecl *ElasticsearchClient) bulkIndex(a interface{}, index string) {
 	}
 }
 
+func (ecl *ElasticsearchClient) SendAlertToBuffer(alert *pb.Alert) {
+	ecl.alertCh <- alert
+}
+
 // Start starts the Elasticsearch client by performing a health check on the gRPC server
 // and starting goroutines to consume messages from the alert channel and bulk index them.
 // The method starts a goroutine for each stream and waits for messages to be received.
 // Additional goroutines consume alert from the alert channel and bulk index them.
 func (ecl *ElasticsearchClient) Start() error {
 	start = time.Now()
-	client := ecl.kaClient
 	ecl.ctx, ecl.cancel = context.WithCancel(context.Background())
-	client.WgServer = &errgroup.Group{}
-	client.Context = ecl.ctx
-	// do healthcheck
-	if ok := client.DoHealthCheck(); !ok {
-		return fmt.Errorf("failed to check the liveness of the gRPC server")
-	}
-	kg.Printf("Checked the liveness of the gRPC server")
-
-	client.WgServer.Go(func() error {
-		for client.Running {
-			res, err := client.AlertStream.Recv()
-			if err != nil {
-				return fmt.Errorf("failed to receive an alert (%s) %s", client.Server, err)
-			}
-			tel, _ := json.Marshal(res)
-			fmt.Printf("%s\n", string(tel))
-
-			select {
-			case ecl.alertCh <- res:
-			case <-client.Context.Done():
-				// The context is over, stop processing results
-				return nil
-			default:
-				//not able to add it to Log buffer
-			}
-		}
-		return nil
-	})
+	var wg sync.WaitGroup
 
 	for i := 0; i < 5; i++ {
+		wg.Add(1)
 		go func() {
 			for {
 				select {
 				case alert := <-ecl.alertCh:
 					ecl.bulkIndex(alert, "alert")
 				case <-ecl.ctx.Done():
-					close(ecl.alertCh)
 					return
 				}
 			}
 		}()
 	}
+	wg.Wait()
 	return nil
 }
 
 // Stop stops the Elasticsearch client and performs necessary cleanup operations.
 // It stops the Kubearmor Relay client, closes the BulkIndexer and cancels the context.
 func (ecl *ElasticsearchClient) Stop() error {
-	logClient := ecl.kaClient
-	logClient.Running = false
-	time.Sleep(2 * time.Second)
-
-	//Destoy KubeArmor Relay Client
-	if err := logClient.DestroyClient(); err != nil {
-		return fmt.Errorf("failed to destroy the kubearmor relay gRPC client (%s)", err.Error())
-	}
-	kg.Printf("Destroyed kubearmor relay gRPC client")
 
 	//Close BulkIndexer
 	if err := ecl.bulkIndexer.Close(ecl.ctx); err != nil {

--- a/relay-server/main.go
+++ b/relay-server/main.go
@@ -84,13 +84,14 @@ func main() {
 
 	// check and start an elasticsearch client
 	if enableEsDashboards == "true" {
-		esCl, err := elasticsearch.NewElasticsearchClient(esUrl, endPoint)
+		esCl, err := elasticsearch.NewElasticsearchClient(esUrl)
 		if err != nil {
 			kg.Warnf("Failed to start a Elasticsearch Client")
 			return
 		}
-		go esCl.Start()
-		defer esCl.Stop()
+		relayServer.ELKClient = esCl
+		go relayServer.ELKClient.Start()
+		defer relayServer.ELKClient.Stop()
 	}
 
 	// == //

--- a/relay-server/main.go
+++ b/relay-server/main.go
@@ -87,6 +87,7 @@ func main() {
 		esCl, err := elasticsearch.NewElasticsearchClient(esUrl, endPoint)
 		if err != nil {
 			kg.Warnf("Failed to start a Elasticsearch Client")
+			return
 		}
 		go esCl.Start()
 		defer esCl.Stop()


### PR DESCRIPTION
```
{"level":"info","ts":"2024-12-16 15:17:16.180767","caller":"log/logger.go:54","msg":"Created a relay server (:32767)"}
{"level":"info","ts":"2024-12-16 15:17:16.180927","caller":"log/logger.go:49","msg":"Started to serve gRPC-based log feeds"}
{"level":"info","ts":"2024-12-16 15:17:16.180945","caller":"log/logger.go:49","msg":"Started to receive log feeds from each node"}
{"level":"info","ts":"2024-12-16 15:17:16.182049","caller":"log/logger.go:49","msg":"Initialized the Kubernetes client"}
{"level":"info","ts":"2024-12-16 15:17:16.185508","caller":"log/logger.go:54","msg":"Added a new client (f12f3795-2e9f-4181-bf6a-2c5d26093aa6, policy) for WatchAlerts"}
{"level":"info","ts":"2024-12-16 15:17:16.185648","caller":"log/logger.go:54","msg":"Added a new client (b70fb7af-10a7-488f-bf63-eca88e583699, system) for WatchLogs"}
{"level":"info","ts":"2024-12-16 15:17:16.186195","caller":"log/logger.go:54","msg":"Checked the liveness of the gRPC server"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1a287fc]

goroutine 63 [running]:
golang.org/x/sync/errgroup.(*Group).Go(0x0, 0xc000652030)
        /go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:70 +0x1c
github.com/kubearmor/kubearmor-relay-server/relay-server/elasticsearch.(*ElasticsearchClient).Start(0xc000506740)
        /usr/src/kubearmor-relay-server/relay-server/elasticsearch/adapter.go:126 +0x13f
created by main.main in goroutine 1
        /usr/src/kubearmor-relay-server/relay-server/main.go:91 +0x388
```

**after fix:**
```
{"level":"info","ts":"2024-12-17 15:57:28.345659","caller":"log/logger.go:54","msg":"Created a relay server (:32767)"}
{"level":"info","ts":"2024-12-17 15:57:28.345760","caller":"log/logger.go:49","msg":"Started to serve gRPC-based log feeds"}
{"level":"info","ts":"2024-12-17 15:57:28.345771","caller":"log/logger.go:49","msg":"Started to receive log feeds from each node"}
{"level":"info","ts":"2024-12-17 15:57:28.348915","caller":"log/logger.go:49","msg":"Initialized the Kubernetes client"}
{"level":"info","ts":"2024-12-17 15:57:28.361226","caller":"log/logger.go:54","msg":"Checked the liveness of KubeArmor's gRPC service (192.168.29.159:32767)"}
{"level":"info","ts":"2024-12-17 15:57:28.361289","caller":"log/logger.go:49","msg":"Started to watch messages from 192.168.29.159:32767"}
{"level":"info","ts":"2024-12-17 15:57:28.361300","caller":"log/logger.go:49","msg":"Started to watch alerts from 192.168.29.159:32767"}
{"level":"info","ts":"2024-12-17 15:57:28.361310","caller":"log/logger.go:49","msg":"Started to watch logs from 192.168.29.159:32767"}
{"level":"warn","ts":"2024-12-17 15:58:51.449813","caller":"log/logger.go:79","msg":"failed to receive a log (192.168.29.159:32767) rpc error: code = Unavailable desc = error reading from server: EOF"}
{"level":"info","ts":"2024-12-17 15:58:51.449880","caller":"log/logger.go:54","msg":"Destroyed the client (192.168.29.159:32767)"}
{"level":"warn","ts":"2024-12-17 15:58:51.450228","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"warn","ts":"2024-12-17 15:58:51.600931","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"warn","ts":"2024-12-17 15:58:56.601869","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"warn","ts":"2024-12-17 15:59:01.603038","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"warn","ts":"2024-12-17 15:59:06.603929","caller":"log/logger.go:84","msg":"Failed to call WatchMessages (192.168.29.159:32767) err=rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 192.168.29.159:32767: connect: connection refused\"\n"}
{"level":"info","ts":"2024-12-17 15:59:15.242529","caller":"log/logger.go:54","msg":"Checked the liveness of KubeArmor's gRPC service (192.168.29.159:32767)"}
{"level":"info","ts":"2024-12-17 15:59:15.242574","caller":"log/logger.go:49","msg":"Started to watch messages from 192.168.29.159:32767"}
{"level":"info","ts":"2024-12-17 15:59:15.242583","caller":"log/logger.go:49","msg":"Started to watch alerts from 192.168.29.159:32767"}
{"level":"info","ts":"2024-12-17 15:59:15.242592","caller":"log/logger.go:49","msg":"Started to watch logs from 192.168.29.159:32767"}
^C{"level":"info","ts":"2024-12-17 16:04:40.105355","caller":"log/logger.go:49","msg":"Terminated the gRPC service"}
{"level":"info","ts":"2024-12-17 16:04:40.105413","caller":"log/logger.go:49","msg":"Destroyed the relay server"}
{"level":"info","ts":"2024-12-17 16:04:40.105449","caller":"log/logger.go:54","msg":"Stopped kubearmor receiver"}
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
2024/12/17 16:04:42 Sucessfuly indexed [13] documents in 7m13.758s (0.029970628783791885 docs/sec)
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
```