### PR TITLE
add maintainer label to container image

### DIFF
--- a/relay-server/Dockerfile
+++ b/relay-server/Dockerfile
@@ -19,6 +19,7 @@ ARG VERSION="latest"
 
 LABEL name="kubearmor-relay-server" \
       vendor="AccuKnox" \
+      maintainer="Barun Acharya, Ramakant Sharma" \
       version=${VERSION} \
       release=${VERSION} \
       summary="kubearmor-relay container image based on redhat ubi" \


### PR DESCRIPTION
add required container label to all container images
ref: https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-metadata-requirements_openshift-sw-cert-policy-container-images